### PR TITLE
Payment type change and refactor

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 import os
 from datetime import timedelta
 from pathlib import Path
-import stripe
+
 
 # Build paths inside the project like this: BASE_DIR / "subdir".
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -173,3 +173,5 @@ Q_CLUSTER = {
     "bulk": 10,
     "orm": "default",
 }
+
+FINE_MULTIPLIER = 2

--- a/payment/helpers.py
+++ b/payment/helpers.py
@@ -1,11 +1,6 @@
-def calculate_fine_payment(expected_return_date, actual_return_date, daily_fee):
-    if actual_return_date > expected_return_date:
-        return (actual_return_date.day - expected_return_date.day) * daily_fee * 200
-    return False
+from datetime import datetime, timedelta
 
-
-def calculate_fee_payment(expected_return_date, borrow_date, daily_fee):
-    calculation = ((expected_return_date.day - borrow_date.day) * daily_fee) * 100
-    if calculation < daily_fee:
-        return daily_fee * 100
-    return calculation
+def calculate_fee_payment(start_date: datetime, end_date: datetime, daily_fee: int) -> int:
+    end_date += timedelta(hours=1)
+    day_count = (end_date - start_date).days
+    return max(1, day_count) * daily_fee

--- a/payment/urls.py
+++ b/payment/urls.py
@@ -6,13 +6,15 @@ from payment.views import (
     PaymentCreateView,
     create_payment_session,
     cancel_payment,
+    success_payment,
 )
 
 urlpatterns = [
     path("", PaymentListView.as_view(), name="payment-list"),
     path("<int:pk>/", PaymentDetailView.as_view(), name="payment-detail"),
-    path("success/<int:pk>/", create_payment_session, name="success"),
-    path("cancel/", cancel_payment, name="cancel_payment"),
+    path("session/<int:pk>/", create_payment_session, name="session-payment"),
+    path("success/", success_payment, name="success-payment"),
+    path("cancel/", cancel_payment, name="cancel-payment"),
 ]
 
 app_name = "payments"


### PR DESCRIPTION
1. Changes in borrowing <--> payment system:
    1.1 refactored payment helper function:
        - now it works both for fine and fee calculations
        - calculation based on timedelta which means more precision and no more end-of-year/month miscalculations
        - added timedelta adjustment to "round up" time within 1 hour span(can be changed)
        - FINE_MULTIPLIER is now a variable in settings so it is can be changed in one place, globally accessable and potentially can be easilly adjusted via env variables and volumes (in case with docker for example)
        
    1.2 BorrowingReturnView no more needs ot call calculate_fine_payment from payment.helpers, no more unnecessary fine calculation since it is not being used anywhere and being recalculated after call is redirected to payment view second time

2. create_payment_session view from payment.views now changes payment type depending if it processes FINE payment. Also it is made to be displayed in payment_info for telegram message (not necessary, was used heavily for debugging so can be changed back if not preferred).

3. Added functionality of successfull paymennts:
    - added success_payment view and url to create endpoint for confirmed payments, passed to stripe session as success_url -> after payment is done user is redirected to "successful" endpoint -> payment is marked as "paid" and saved -> user gets his "thank you!" message and link to payment detail
    - ulr for create_payment_session view is now called "session-payment" with "/session/" endpoint url, changes done accordingly to views in borrowing.views